### PR TITLE
Autoversioning from branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,19 @@
+plugins {
+  // https://github.com/nemerosa/versioning
+  id 'net.nemerosa.versioning' version '2.8.2'
+}
+
 ext {
   interlokParentGradle = "https://raw.githubusercontent.com/adaptris-labs/interlok-build-parent/master/build.gradle"
-  interlokVersion = '3.9-SNAPSHOT'
+  interlokVersion = '3.10-SNAPSHOT'
   // Include the WAR file since by default it is excluded.
   includeWar='true'
 }
 
 allprojects {
   apply from: "${interlokParentGradle}"
+  // specify the version of the configuration.
+  version=versioning.info.branch
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ ext {
 allprojects {
   apply from: "${interlokParentGradle}"
   // specify the version of the configuration.
-  version=versioning.info.branch
+  version=versioning.info.full
 }
 
 


### PR DESCRIPTION
## Motivation

The build parent automatically builds a _version.properties_ which, if you don't specify a version, leaves the version as __unspecified__. Since we anticipate that a lot of people are using an SCM of sorts to host their configuration (git/svn); we should be able to build a simple version number based on the branch + hash of the commit.

## Modification

Add the versioning plugin from https://github.com/nemerosa/versioning and use the versioning object that's available.

## Result

Rather than "unspecified" the version changes to the branch name based on the versioning info from https://github.com/nemerosa/versioning

## Testing

Well, you should see build/distribution/config/version.properties contain the branch name if you check this bad boy out and run `gradle check assemble`

If you have configuration that isn't stored in scm then `build.version=` rather than `build.version=unspecified`
