### PR TITLE
Actually make use of version.properties from nemerosa.

### DIFF
--- a/config-project.json
+++ b/config-project.json
@@ -5,9 +5,17 @@
     "local-dev" : { }
   },
   "variableXpaths" : {
-    "/adapter/channel-list/channel[unique-id=\"JSON-CSV\"]/auto-start" : "${jetty.channel.autostart}"
+    "/adapter/channel-list/channel[unique-id=\"JSON-CSV\"]/auto-start" : "${jetty.channel.autostart}",
+    "/adapter/channel-list/channel[unique-id=\"JSON-CSV\"]/workflow-list/standard-workflow[unique-id=\"receive-json-return-csv\"]/service-collection/services/add-metadata-service[unique-id=\"add-build-metadata\"]/metadata-element[2]/value" : "${build.version}",
+    "/adapter/channel-list/channel[unique-id=\"JSON-CSV\"]/workflow-list/standard-workflow[unique-id=\"receive-json-return-csv\"]/service-collection/services/add-metadata-service[unique-id=\"add-build-metadata\"]/metadata-element[1]/value" : "${interlok.core.version}"
   },
   "uidInXincludeCompntListFileName" : false,
   "xincludeXpaths" : { },
+  "additionalFiles" : {
+    "jetty.xml" : "jetty.xml",
+    "webdefault.xml" : "webdefault.xml",
+    "bootstrap.properties" : "bootstrap.properties",
+    "log4j2.xml" : "log4j2.xml"
+  },
   "structured" : true
 }

--- a/src/main/interlok/config/adapter.xml
+++ b/src/main/interlok/config/adapter.xml
@@ -42,6 +42,17 @@
           <service-collection class="service-list">
             <unique-id>high-shirley</unique-id>
             <services>
+              <add-metadata-service>
+                <unique-id>add-build-metadata</unique-id>
+                <metadata-element>
+                  <key>X-Interlok-Release</key>
+                  <value>${interlok.core.version}</value>
+                </metadata-element>
+                <metadata-element>
+                  <key>X-Interlok-Build</key>
+                  <value>${build.version}</value>
+                </metadata-element>
+              </add-metadata-service>
               <json-to-csv>
                 <unique-id>json-array-to-csv</unique-id>
                 <preference-builder class="csv-basic-preference-builder">
@@ -52,7 +63,11 @@
                 <unique-id>send-response</unique-id>
                 <http-status>200</http-status>
                 <content-type>text/plain</content-type>
-                <response-header-provider class="jetty-no-response-headers"/>
+                <response-header-provider class="jetty-metadata-response-headers">
+                  <filter class="regex-metadata-filter">
+                    <include-pattern>^X-Interlok.*$</include-pattern>
+                  </filter>
+                </response-header-provider>
               </jetty-response-service>
             </services>
           </service-collection>

--- a/src/main/interlok/config/bootstrap.properties
+++ b/src/main/interlok/config/bootstrap.properties
@@ -2,9 +2,11 @@ adapterConfigUrl.0=file://localhost/./config/adapter.xml
 managementComponents=jmx:jetty
 webServerConfigUrl=./config/jetty.xml
 jmxserviceurl=service:jmx:jmxmp://localhost:5555
-preProcessors=xinclude:variableSubstitution
+preProcessors=variableSubstitution
 variable-substitution.properties.url.0=file://localhost/./config/variables.properties
 variable-substitution.properties.url.1=file://localhost/./config/variables-local.properties
+# Make sure it's last because it gets auto-generated.
+variable-substitution.properties.url.2=file://localhost/./config/version.properties
 variable-substitution.impl=strictWithLogging
 
 enableLocalJndiServer=true

--- a/src/main/interlok/config/variables.properties
+++ b/src/main/interlok/config/variables.properties
@@ -1,1 +1,3 @@
 jetty.channel.autostart=false
+interlok.core.version=UNKNOWN
+build.version=Build Version Unknown


### PR DESCRIPTION
## Motivation

Since we have the plugin from  https://github.com/nemerosa/versioning enabled, we may as well emit that information in our HTTP headers

## Modification

* Add version.properties into the varsub chain as the last entry (so that it takes ultimate precedence)
* Add an add-metadata-service to include `build.version` and `interlok.core.version`
* Modify response so that some `X-Interlok` headers are sent as part of the HTTP response headers.

## Result

```console
$ curl -si -XPOST "http://localhost:8080/api/csv" -d '[{"key1":"value1", "key2":"value2"}]'
HTTP/1.1 200 OK
X-Interlok-Build: make-use-of-version.properties-04f5bed
X-Interlok-Release: 3.10.1-RELEASE
Content-Type: text/plain
Transfer-Encoding: chunked
Server: Jetty(9.4.28.v20200408)

key1,key2
value1,value2
```

## Testing

As above, but 

* Bear in mind that auto-start is set to false, so you will need to start the channel explicitly (via the UI or whatever)
* the `X-Interlok-Build` head may not be exactly the same (depending on what the branch is).
